### PR TITLE
[source build] fix dependency problems

### DIFF
--- a/resources/venv.bash
+++ b/resources/venv.bash
@@ -80,8 +80,7 @@ pretty_header "PyPi Dependencies"
 pip3 install wheel
 pip3 install setuptools==45.2.0
 pip3 install vcstool==0.2.14
-pip3 install colcon-core==0.6.0
-pip3 install colcon-common-extensions==0.2.1
+pip3 install colcon-common-extensions==0.2.1  # this will fetch the appropriate version of colcon-core as well
 
 echo ""
 echo "Leave the virtual environment with 'deactivate'"


### PR DESCRIPTION
`colcon-common-extensions`' fetched a later version of `colcon_python_setup_py`, which in turn, required a later version of `colcon_core` that resulted in a version conflict, refer to https://github.com/kobuki-base/kobuki_documentation/actions/runs/339815780/workflow. This commit takes out the potential for a version conflict and let's pip do it's thing.